### PR TITLE
fix same proxy from getting same empty list

### DIFF
--- a/__tests/test_reactive.py
+++ b/__tests/test_reactive.py
@@ -432,6 +432,13 @@ class Test_base_case:
 
         assert data["s"] is s
 
+    def test_should_same_proxy_from_getting_same_empty_list(self):
+        data = signal({"rows": []})
+
+        first = data.value["rows"]
+        second = data.value["rows"]
+        assert first is second
+
 
 class Test_to_raw:
     def test_signal_list(self):

--- a/signe/core/reactive.py
+++ b/signe/core/reactive.py
@@ -82,7 +82,7 @@ def reactive(
     obj_id = id(obj)
     proxy = _proxy_maps.get(obj_id)
 
-    if proxy:
+    if proxy is not None:
         return proxy  # type: ignore
 
     scheduler = scheduler or get_default_scheduler()


### PR DESCRIPTION
```python
data = signal({"rows": []})

first = data.value["rows"]
second = data.value["rows"]
assert first is second
```