### PR TITLE
Fix list del item not effect trigger

### DIFF
--- a/__tests/test_reactive.py
+++ b/__tests/test_reactive.py
@@ -380,6 +380,20 @@ class Test_base_case:
 
         assert dummy == ["1,2,3", "1,66,2,3"]
 
+    def test_list_del_item(self):
+        dummy = []
+
+        data = signal(["1", "2", "3"])
+
+        @effect
+        def _():
+            dummy.append(",".join(data.value))
+
+        assert dummy == ["1,2,3"]
+        del data.value[1]
+
+        assert dummy == ["1,2,3", "1,3"]
+
     def test_dict_in(self):
         dummy = []
         data = signal({"a": 1, "b": 2})

--- a/signe/core/reactive.py
+++ b/signe/core/reactive.py
@@ -348,6 +348,14 @@ class ListProxy(UserList):
 
         return False
 
+    def __delitem__(self, i: slice) -> None:
+        super().__delitem__(i)
+
+        @self.__batch
+        def _():
+            self._dep_manager.triggered("len", len(self.data), EffectState.NEED_UPDATE)
+            self._dep_manager.triggered("__iter__", None, EffectState.NEED_UPDATE)
+
     def to_raw(self):
         return self.data
 


### PR DESCRIPTION
```python
data = signal(["a", "b"], is_shallow=False)

@effect
def _():
    print("nums:", str(data.value))

del data.value[0]
```